### PR TITLE
Dev/input script htlc

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ console.log(`coinbaseTx hex = ${conbaseTx.toString("hex")}`)
 - [ ] parallelize `pow` with Web Workers
 
 ## Release Notes:
+- 0.13.0 Added an option for unlocking HTLC scripts.
 - 0.12.0 Added branching helper `iff` and predicates `has` and `hasNo`. Use them in `tx-build` allow to pass `scriptPubKey` for tx outputs.
 - 0.11.0 Added custom types (`Address`, 'TxConfig', 'TxVin'). Typeforce main `tx-build` functions.
 - 0.10.0 Allow to create a custom locking script for transaction outputs. See `makeBufferOutput`.

--- a/src/compose-build.js
+++ b/src/compose-build.js
@@ -16,6 +16,7 @@ const prop = (propName, fn) => obj => fn(obj[propName])
 // prop :: (Array -> Fn a) -> (Obj -> a)
 const props = (propNames, fn) => obj => {
   const props = propNames.map(propName => obj[propName])
+  console.log(`props: `, props)
   return fn.apply(this, props)
 }
 

--- a/test/tx-build.test.js
+++ b/test/tx-build.test.js
@@ -161,6 +161,17 @@ describe('builder', function () {
     })
   })
 
+  describe.only('vinScript HTLC', function () {
+    const keyPair = fixtureNode.keyPair
+    const secretHex = '56c44dc6ac176bb534679a8e4b6979b1'
+    const expectedScript = '4730440220764bbe9ddff67409310c04ffb34fe937cc91c3d55303158f91a32bed8d9d7a7b02207fb30f6b9aaef93da8c88e2b818d993ad65aae54860c3de56c6304c57252cce1012103a6afa2211fc96a4130e767da4a9e802f5e922a151c5cd6d4bffa80358dd1f9a31056c44dc6ac176bb534679a8e4b6979b1'
+    it('should create vin script', function () {
+      const script = vinScript(buildTxCopy)(fixture.tx, 0)(keyPair, secretHex)
+      // console.log(`script: ${script.toString('hex')}`)
+      assert.equal(script.toString('hex'), expectedScript)
+    })
+  })
+
   describe('bufferInput', function () {
     const keyPair = fixtureNode.keyPair
     it('should build vin', function () {


### PR DESCRIPTION
Added option for unlocking HTLC script. If transaction config has `htlcSecret` property with a hex string then it will be added to the `scriptSig` for an input script.